### PR TITLE
fixed deprecation warning on apt

### DIFF
--- a/intro-ansible/06-configuring-servers/roles/common/tasks/security.yml
+++ b/intro-ansible/06-configuring-servers/roles/common/tasks/security.yml
@@ -1,14 +1,9 @@
 # install security configuration
 - name: ensure python packages are installed
   apt:
-    name: "{{ item }}"
+    name: ['python3-pip', 'python3-dev', 'fail2ban']
     update_cache: yes
   become: yes
-  with_items:
-    - "python3-pip"
-    - "python3-dev"
-    - "fail2ban"
-
 
 - name: enable SSH within the firewall
   ufw: rule=allow port=22

--- a/intro-ansible/06-configuring-servers/roles/database/tasks/postgresql.yml
+++ b/intro-ansible/06-configuring-servers/roles/database/tasks/postgresql.yml
@@ -1,12 +1,7 @@
 # install and configure PostgreSQL database
 - name: ensure postgresql database packages are installed
-  apt: name={{ item }}
-  with_items:
-    - postgresql
-    - libpq-dev
-    - python3-psycopg2
-    - postgresql-client
-    - postgresql-client-common
+  apt: 
+    name: ['postgresql', 'libpq-dev', 'python3-psycopg2', 'postgresql-client', 'postgresql-client-common']
   become: yes
 
 


### PR DESCRIPTION
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions is deprecated. Instead of
using a loop to supply multiple items and specifying `name: "{{ item }}"`, please use `name: ['python3-pip',
'python3-dev', 'fail2ban']` and remove the loop. This feature will be removed in version 2.11. Deprecation
warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.