### PR TITLE
change user root to become

### DIFF
--- a/intro-ansible/06-configuring-servers/init_config.yml
+++ b/intro-ansible/06-configuring-servers/init_config.yml
@@ -1,6 +1,6 @@
 # sets up a non-root user and group
 - name: apply initial config to server
   hosts: init_config
-  user: root
+  become: "yes"
   roles:
     - init_config


### PR DESCRIPTION
user: root is a real issue for clouds (not the sponsors) that disable root access out of the gate (AWS)